### PR TITLE
fixed import pycaffe error on Max OSX

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -45,6 +45,7 @@ add_dependencies(pycaffe protoPy)
 target_link_libraries(pycaffe ${CAFFE_STATIC_LINK} ${PYTHON_LIBRARIES} ${Boost_LIBRARIES})
 
 set_target_properties(pycaffe PROPERTIES PREFIX "")
+set_target_properties(pycaffe PROPERTIES SUFFIX ".so")
 set_target_properties(pycaffe PROPERTIES OUTPUT_NAME "_caffe")
 
 ###    Install    #############################################################


### PR DESCRIPTION
I've fixed import error of pycaffe on Mac OS.

When using pycaffe module on Mac, import error has occured.

I tried to below command.

```
python -c 'import caffe; print caffe'
```

and following error has occured.

```
Python 2.7.9 (default, Jan  7 2015, 11:49:12)
[GCC 4.2.1 Compatible Apple LLVM 6.0 (clang-600.0.56)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import caffe
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/conta/workspace/Others/caffe/build/install/python/caffe/__init__.py", line 1, in <module>
    from .pycaffe import Net, SGDSolver
  File "/Users/conta/workspace/Others/caffe/build/install/python/caffe/pycaffe.py", line 10, in <module>
    from ._caffe import Net, SGDSolver
ImportError: No module named _caffe
```

I think the error comes from that cmake command generates _caffe.dylib on Mac, not _caffe.so.
Python cannot import *.dylib module.

It can solve by adding a following change on https://github.com/BVLC/caffe/blob/dev/python/CMakeLists.txt#L47

```
set_target_properties(pycaffe PROPERTIES SUFFIX ".so")
```

It works well on my PC.
I'd like to review and merge it.
